### PR TITLE
微調整

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,12 +16,12 @@ RUN apt-get update \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& cd /etc/apache2/mods-enabled \
-    && ln -s ../mods-available/rewrite.load
-RUN yes | pecl install xdebug \
+    && ln -s ../mods-available/rewrite.load \
+    && yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_host=10.254.254.254" >> /usr/local/etc/php/conf.d/xdebug.ini
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
-RUN composer self-update
+    && echo "xdebug.remote_host=10.254.254.254" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer \
+    && composer self-update

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@
 
 ## 設定ファイルの配置
 
-docker/docker-compose.yml と docker/Dockerfile を、プロジェクトディレクトリの直下にコピーします。
+docker/docker-compose.ym をプロジェクトディレクトリの直下にコピーします。
  
 ## コンテナを作成して起動する
 


### PR DESCRIPTION
配布するコンテナイメージの場合、RUNは一個にまとめた方が、layerが少なくなって軽くなるのでできるだけまとめた方がよいのでまとめました。

